### PR TITLE
updating encodeQA for collection 1 Landsat MSS/TM/ETM+/OLI bit designations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,4 +43,4 @@ LinkingTo: Rcpp,
     RcppArmadillo
 License: GPL (>=3)
 LazyData: true
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1

--- a/R/encodeQA.R
+++ b/R/encodeQA.R
@@ -1,70 +1,89 @@
 #' Encode QA Conditions to Integers
 #' 
-#' Intended for use with the Landsat 8 OLI QA band. Converts pixel quality flags from human readable to integer, which can then be used to 
-#' subset the QA image. Please be aware of the default settings which differ for different parameters.
-#' NOTE: THE NEW USGS LANDSAT COLLECTION 1 DATA HAS CHANGED THE QA BITWORD ASSIGNMENTS. THIS IS NOT YET IMPLEMENTED HERE.
-#' DO NOT USE encodeQA, decodeQA and classifyQA FOR LANDSAT COLLECTION 1 DATA (yet)! 
+#' Intended for use with Landsat 16-bit QA bands. Converts pixel quality flags from human readable to integer, which can then be used to 
+#' subset a QA image. Please be aware of the default settings which differ for different parameters. 
+#' Depending on, which \code{sensor} and \code{legacy} is selected, some quality parameters are not used, since the sequences of available bitwise quality designations differ per sensor and collection.
 #' 
 #' @param fill Designated fill. Options: \code{c("yes", "no", "all")}. 
-#' @param droppedFrame Dropped frame. Options: \code{c("yes", "no", "all")}.
 #' @param terrainOcclusion Terrain induced occlusion. Options: \code{c("yes", "no", "all")}.
-#' @param water Water confidence. Options: \code{c("na", "low", "med", "high", "all")}.
+#' @param radSaturation Number of bands that contain radiometric saturation. Options: \code{c("na", "low", "med", "high", "all")} for no bands, 1-2 bands, 3-4 bands, 5 or more bands contain saturation.
+#' @param cloudMask Cloud mask. Options: \code{c("yes", "no", "all")}.
+#' @param cloud Cloud confidence. Options: \code{c("na", "low", "med", "high", "all")}.
+#' @param cloudShadow Cloud shadow confidence. Options: \code{c("yes", "no", "all")}.
 #' @param snow Snow / ice confidence.  Options: \code{c("na", "low", "med", "high", "all")}.
 #' @param cirrus Cirrus confidence.  Options: \code{c("na", "low", "med", "high", "all")}.
-#' @param cloud Cloud confidence. Options: \code{c("na", "low", "med", "high", "all")}.
+#' @param water Water confidence. Options: \code{c("na", "low", "med", "high", "all")}.
+#' @param droppedFrame Dropped frame. Options: \code{c("yes", "no", "all")}.
+#' @param sensor Sensor to encode. Options: \code{c("OLI", "TIRS", "ETM+", "TM", "MSS")}.
+#' @param legacy Encoding systematic Options: \code{c("collection1", "pre_collection")}. Default is "collection1" for the Landsat Collection 1 8-bit quality designations. Use "pre_collection" for imagery downloaded before the Collection 1 quality designations were introduced
 #' 
 #' @note 
-#' Only currently populated bits are available as arguments, i.e. vegetation confidence, cloud shadow and bit nr. 3. are currently useless and hence not available.
+#' Only currently populated bits are available as arguments.
 #' 
 #' @references 
-#' \url{https://landsat.usgs.gov/qualityband} 
+#' \url{https://landsat.usgs.gov/qualityband} for pre collection quality designations (\code{legacy = "pre_collection"})
+#' \url{https://landsat.usgs.gov/collectionqualityband} for Collection 1 quality designations (\code{legacy = "collection1"})
 #' @export 
 #' @return
 #' Returns the Integer value for the QA values
 #' @examples 
 #' encodeQA(snow = "low", cirrus = c("med", "high"), cloud = "high")
-encodeQA <- function(fill = "no", droppedFrame = "no", terrainOcclusion = "no", 
-        water = "all", snow = "all", cirrus = "all", cloud = "all"){
-    
-    ## Input checks
-    s <- list(fill = fill, droppedFrame = droppedFrame, terrainOcclusion = terrainOcclusion)
-    lapply(names(s), function(i) if(any(!s[[i]] %in% c("yes", "no", "all"))) stop(i, " is a single bit parameter. Can digest only values c('yes', 'no', 'all')", call.=FALSE))
-    s <- list(water = water, snow = snow, cirrus = cirrus, cloud = cloud)
-    lapply(names(s), function(i) if(any(!s[[i]] %in% c("na", "low", "med", "high", "all"))) stop(i, " is a double bit parameter. Can digest only values c('na', 'low', 'med', 'high', 'all')", call.=FALSE))
-    
-    ## Convert to bit representation
-    sing <- list(no = "0", yes = "1", all = c("0", "1"))
-    doub <- c(na = "00", low = "01", med = "10", high = "11")
-    doub <- c(as.list(doub), list(all = doub))
-    
-    xfill <- sing[fill]
-    xdroppedFrame <- sing[droppedFrame]
-    xterrainOcclusion <- sing[terrainOcclusion]
-    xreserved <- "0"
-    xwater <- doub[water]
-    xcloudShadow <- "00"
-    xvegetation  <- "00"
-    xsnow   <- doub[snow]
-    xcirrus <- doub[cirrus]
-    xcloud  <- doub[cloud]
-    
-    ## Possible combinations
-    li  <- list(xcloud, xcirrus, xsnow, xvegetation, xcloudShadow, xwater, xreserved, xterrainOcclusion, xdroppedFrame, xfill)
-    names(li) <- c("cloud", "cir", "snow", "veg", "cs", "water", "res", "ter", "drop", "fill")
-    li <- lapply(li, unlist)
-    li <- expand.grid(li)
-    
-    ## Convert to integer
-    binWords <-  apply(li, 1, paste, collapse = "")
-    
-    strtoi(binWords, base = 2)
+encodeQA <- function(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "all", cloud = "all", 
+                     cloudShadow = "all", snow = "all", cirrus = "all", droppedPixel = "no",
+                     water = "all", droppedFrame = "no", sensor = "OLI", legacy = "collection1"){
+  
+  ## Input checks
+  if(legacy == "pre_collection" & !any(sensor %in% c("OLI", "TIRS"))) stop("For argument legacy = 'pre_collection', argument sensor can only be 'OLI' or 'TIRS'.", call.=FALSE)
+  
+  s <- list(fill = fill, terrainOcclusion = terrainOcclusion, cloudMask = cloudMask, droppedFrame = droppedFrame, droppedPixel = droppedPixel)
+  lapply(names(s), function(i) if(any(!s[[i]] %in% c("yes", "no", "all"))) stop(i, " is a single bit parameter. Can digest only values c('yes', 'no', 'all')", call.=FALSE))
+  s <- list(water = water, snow = snow, cirrus = cirrus, cloud = cloud, cloudShadow = cloudShadow, radSaturation = radSaturation)
+  lapply(names(s), function(i) if(any(!s[[i]] %in% c("na", "low", "med", "high", "all"))) stop(i, " is a double bit parameter. Can digest only values c('na', 'low', 'med', 'high', 'all')", call.=FALSE))
+  
+  ## Convert to bit representation
+  sing <- list(no = "0", yes = "1", all = c("0", "1"))
+  doub <- c(na = "00", low = "01", med = "10", high = "11")
+  doub <- c(as.list(doub), list(all = doub))
+  
+  xfill <- sing[fill]
+  xterrainOcclusion <- sing[terrainOcclusion]
+  xradSaturation <- doub[radSaturation]
+  xcloud <- sing[cloudMask]
+  xcloudConfidence <- doub[cloud]
+  xcloudShadow <- doub[cloudShadow]
+  xsnow <- doub[snow]
+  xcirrus <- doub[cirrus]
+  xdroppedPixel <- sing[droppedPixel]
+  xwater <- doub[water]
+  xdroppedFrame <- sing[droppedFrame]
+  
+  xresSing <- "0"
+  xresDoub <- "00"
+  
+  ## Possible combinations
+  if(legacy == "pre_collection"){
+    li  <- c(xcloudConfidence, xcirrus, xsnow, rep(xresDoub, 2), xwater, xresSing, xterrainOcclusion, xdroppedFrame, xfill)
+    names(li) <- c("cc", "cir", "snow", "veg", "cs", "water", "res", "ter", "drop", "fill")
+  }
+  if(legacy == "collection1"){
+    if(any(sensor %in% c("OLI", "TIRS"))) li <- c(rep(xresSing, 3), xcirrus, xsnow, xcloudShadow, xcloudConfidence, xcloud, xradSaturation, xterrainOcclusion, xfill)
+    if(any(sensor %in% c("TM", "ETM+"))) li <- c(rep(xresSing, 3), xresDoub, xsnow, xcloudShadow, xcloudConfidence, xcloud, xradSaturation, xterrainOcclusion, xfill)
+    if(sensor == "MSS") li <- c(rep(xresSing, 3), rep(xresDoub, 3), xcloudConfidence, xcloud, xradSaturation, xterrainOcclusion, xfill)
+    names(li) <- c(rep("res", 3), "cir", "snow", "cs", "cc", "cloudMask", "radSat", "ter", "fill")
+  }
+  
+  li <- lapply(li, unlist)
+  li <- expand.grid(li)
+  
+  ## Convert to integer
+  binWords <-  apply(li, 1, paste, collapse = "")
+  
+  strtoi(binWords, base = 2)
 }
 
 #' Decode QA flags to bit-words
 #' 
-#' Intended for use with the Landsat 8 OLI QA band. Decodes pixel quality flags from integer to bit-words.
-#' NOTE: THE NEW USGS LANDSAT COLLECTION 1 DATA HAS CHANGED THE QA BITWORD ASSIGNMENTS. THIS IS NOT YET IMPLEMENTED HERE.
-#' DO NOT USE encodeQA, decodeQA and classifyQA FOR LANDSAT COLLECTION 1 DATA (yet)! 
+#' Intended for use with Landsat 16-bit QA bands. Decodes pixel quality flags from integer to bit-words.
 #' 
 #' @param x Integer (16bit)
 #' @export
@@ -72,6 +91,6 @@ encodeQA <- function(fill = "no", droppedFrame = "no", terrainOcclusion = "no",
 #' @examples
 #' decodeQA(53248)
 decodeQA <- function(x){
-    bit <- intToBits(x)
-    paste(tail(rev(as.integer(bit)), 16), collapse="")                        
+  bit <- intToBits(x)
+  paste(tail(rev(as.integer(bit)), 16), collapse="")                        
 }

--- a/R/encodeQA.R
+++ b/R/encodeQA.R
@@ -14,6 +14,7 @@
 #' @param cirrus Cirrus confidence.  Options: \code{c("na", "low", "med", "high", "all")}.
 #' @param water Water confidence. Options: \code{c("na", "low", "med", "high", "all")}.
 #' @param droppedFrame Dropped frame. Options: \code{c("yes", "no", "all")}.
+#' @param droppedPixel Dropped pixel. Options: \code{c("yes", "no", "all")}.
 #' @param sensor Sensor to encode. Options: \code{c("OLI", "TIRS", "ETM+", "TM", "MSS")}.
 #' @param legacy Encoding systematic Options: \code{c("collection1", "pre_collection")}. Default is "collection1" for the Landsat Collection 1 8-bit quality designations. Use "pre_collection" for imagery downloaded before the Collection 1 quality designations were introduced
 #' 

--- a/man/classifyQA.Rd
+++ b/man/classifyQA.Rd
@@ -2,10 +2,11 @@
 % Please edit documentation in R/classifyQA.R
 \name{classifyQA}
 \alias{classifyQA}
-\title{Classify Landsat8 QA Band}
+\title{Classify Landsat QA bands}
 \usage{
 classifyQA(img, type = c("background", "cloud", "cirrus", "snow",
-  "water"), confLayers = FALSE, ...)
+  "water"), confLayers = FALSE, sensor = "OLI",
+  legacy = "collection1", ...)
 }
 \arguments{
 \item{img}{RasterLayer. Landsat 8 OLI QA band.}
@@ -13,6 +14,10 @@ classifyQA(img, type = c("background", "cloud", "cirrus", "snow",
 \item{type}{Character. Classes which should be returned. One or more of c("background", "cloud", "cirrus","snow", "water").}
 
 \item{confLayers}{Logical. Return one layer per class classified by confidence levels, i.e. cloud:low, cloud:med, cloud:high.}
+
+\item{sensor}{Sensor to encode. Options: \code{c("OLI", "TIRS", "ETM+", "TM", "MSS")}.}
+
+\item{legacy}{Encoding systematic Options: \code{c("collection1", "pre_collection")}. Default is "collection1" for the Landsat Collection 1 8-bit quality designations. Use "pre_collection" for imagery downloaded before the Collection 1 quality designations were introduced}
 
 \item{...}{further arguments passed to \link[raster]{writeRaster}}
 }
@@ -37,8 +42,6 @@ high   \tab 3L \cr
 }
 \description{
 extracts five classes from QA band: background, cloud, cirrus, snow and water.
-NOTE: THE NEW USGS LANDSAT COLLECTION 1 DATA HAS CHANGED THE QA BITWORD ASSIGNMENTS. THIS IS NOT YET IMPLEMENTED HERE.
-DO NOT USE encodeQA, decodeQA and classifyQA FOR LANDSAT COLLECTION 1 DATA (yet)!
 }
 \details{
 By default each class is queried for *high* confidence. See \link{encodeQA} for details. To return the different confidence levels per condition use \code{confLayers=TRUE}.

--- a/man/decodeQA.Rd
+++ b/man/decodeQA.Rd
@@ -10,9 +10,7 @@ decodeQA(x)
 \item{x}{Integer (16bit)}
 }
 \description{
-Intended for use with the Landsat 8 OLI QA band. Decodes pixel quality flags from integer to bit-words.
-NOTE: THE NEW USGS LANDSAT COLLECTION 1 DATA HAS CHANGED THE QA BITWORD ASSIGNMENTS. THIS IS NOT YET IMPLEMENTED HERE.
-DO NOT USE encodeQA, decodeQA and classifyQA FOR LANDSAT COLLECTION 1 DATA (yet)!
+Intended for use with Landsat 16-bit QA bands. Decodes pixel quality flags from integer to bit-words.
 }
 \examples{
 decodeQA(53248)

--- a/man/encodeQA.Rd
+++ b/man/encodeQA.Rd
@@ -4,39 +4,53 @@
 \alias{encodeQA}
 \title{Encode QA Conditions to Integers}
 \usage{
-encodeQA(fill = "no", droppedFrame = "no", terrainOcclusion = "no",
-  water = "all", snow = "all", cirrus = "all", cloud = "all")
+encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na",
+  cloudMask = "all", cloud = "all", cloudShadow = "all",
+  snow = "all", cirrus = "all", droppedPixel = "no", water = "all",
+  droppedFrame = "no", sensor = "OLI", legacy = "collection1")
 }
 \arguments{
 \item{fill}{Designated fill. Options: \code{c("yes", "no", "all")}.}
 
-\item{droppedFrame}{Dropped frame. Options: \code{c("yes", "no", "all")}.}
-
 \item{terrainOcclusion}{Terrain induced occlusion. Options: \code{c("yes", "no", "all")}.}
 
-\item{water}{Water confidence. Options: \code{c("na", "low", "med", "high", "all")}.}
+\item{radSaturation}{Number of bands that contain radiometric saturation. Options: \code{c("na", "low", "med", "high", "all")} for no bands, 1-2 bands, 3-4 bands, 5 or more bands contain saturation.}
+
+\item{cloudMask}{Cloud mask. Options: \code{c("yes", "no", "all")}.}
+
+\item{cloud}{Cloud confidence. Options: \code{c("na", "low", "med", "high", "all")}.}
+
+\item{cloudShadow}{Cloud shadow confidence. Options: \code{c("yes", "no", "all")}.}
 
 \item{snow}{Snow / ice confidence.  Options: \code{c("na", "low", "med", "high", "all")}.}
 
 \item{cirrus}{Cirrus confidence.  Options: \code{c("na", "low", "med", "high", "all")}.}
 
-\item{cloud}{Cloud confidence. Options: \code{c("na", "low", "med", "high", "all")}.}
+\item{droppedPixel}{Dropped pixel. Options: \code{c("yes", "no", "all")}.}
+
+\item{water}{Water confidence. Options: \code{c("na", "low", "med", "high", "all")}.}
+
+\item{droppedFrame}{Dropped frame. Options: \code{c("yes", "no", "all")}.}
+
+\item{sensor}{Sensor to encode. Options: \code{c("OLI", "TIRS", "ETM+", "TM", "MSS")}.}
+
+\item{legacy}{Encoding systematic Options: \code{c("collection1", "pre_collection")}. Default is "collection1" for the Landsat Collection 1 8-bit quality designations. Use "pre_collection" for imagery downloaded before the Collection 1 quality designations were introduced}
 }
 \value{
 Returns the Integer value for the QA values
 }
 \description{
-Intended for use with the Landsat 8 OLI QA band. Converts pixel quality flags from human readable to integer, which can then be used to 
-subset the QA image. Please be aware of the default settings which differ for different parameters.
-NOTE: THE NEW USGS LANDSAT COLLECTION 1 DATA HAS CHANGED THE QA BITWORD ASSIGNMENTS. THIS IS NOT YET IMPLEMENTED HERE.
-DO NOT USE encodeQA, decodeQA and classifyQA FOR LANDSAT COLLECTION 1 DATA (yet)!
+Intended for use with Landsat 16-bit QA bands. Converts pixel quality flags from human readable to integer, which can then be used to 
+subset a QA image. Please be aware of the default settings which differ for different parameters. 
+Depending on, which \code{sensor} and \code{legacy} is selected, some quality parameters are not used, since the sequences of available bitwise quality designations differ per sensor and collection.
 }
 \note{
-Only currently populated bits are available as arguments, i.e. vegetation confidence, cloud shadow and bit nr. 3. are currently useless and hence not available.
+Only currently populated bits are available as arguments.
 }
 \examples{
 encodeQA(snow = "low", cirrus = c("med", "high"), cloud = "high")
 }
 \references{
-\url{https://landsat.usgs.gov/qualityband}
+\url{https://landsat.usgs.gov/qualityband} for pre collection quality designations (\code{legacy = "pre_collection"})
+\url{https://landsat.usgs.gov/collectionqualityband} for Collection 1 quality designations (\code{legacy = "collection1"})
 }

--- a/tests/testthat/test-encodeQA.R
+++ b/tests/testthat/test-encodeQA.R
@@ -1,0 +1,102 @@
+context("test-encodeqa")
+
+test_that("encodeQA OLI collection1 pixel value matching", {
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "na", cloudShadow = "na",
+                        snow = "na", cirrus = "na", sensor = "OLI", legacy = "collection1"), 0)
+  expect_equal(encodeQA(fill = "yes", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "na", cloudShadow = "na",
+                        snow = "na", cirrus = "na", sensor = "OLI", legacy = "collection1"), 1)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "yes", radSaturation = "na", cloudMask = "no", cloud = "na", cloudShadow = "na",
+                        snow = "na", cirrus = "na", sensor = "OLI", legacy = "collection1"), 2)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "low", cirrus = "low", sensor = "OLI", legacy = "collection1"), 2720)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "low", cloudMask = "yes", cloud = "high", cloudShadow = "low",
+                        snow = "low", cirrus = "low", sensor = "OLI", legacy = "collection1"), 2804)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "high", cloudMask = "no", cloud = "low", cloudShadow = "high",
+                        snow = "low", cirrus = "low", sensor = "OLI", legacy = "collection1"), 2988)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "high", cirrus = "low", sensor = "OLI", legacy = "collection1"), 3744)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "low", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "high", cirrus = "low", sensor = "OLI", legacy = "collection1"), 3748)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "low", cloudShadow = "high",
+                        snow = "low", cirrus = "high", sensor = "OLI", legacy = "collection1"), 7072)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "low", cloudMask = "no", cloud = "low", cloudShadow = "high",
+                        snow = "low", cirrus = "high", sensor = "OLI", legacy = "collection1"), 7076)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "high", cloudMask = "no", cloud = "med", cloudShadow = "high",
+                        snow = "low", cirrus = "high", sensor = "OLI", legacy = "collection1"), 7116)
+})
+
+test_that("encodeQA TM collection1 pixel value matching", {
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "na", cloudShadow = "na",
+                        snow = "na", sensor = "TM", legacy = "collection1"), 0)
+  expect_equal(encodeQA(fill = "yes", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "na", cloudShadow = "na",
+                        snow = "na", sensor = "TM", legacy = "collection1"), 1)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "yes", radSaturation = "na", cloudMask = "no", cloud = "na", cloudShadow = "na",
+                        snow = "na", sensor = "TM", legacy = "collection1"), 2)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "low", sensor = "TM", legacy = "collection1"), 672)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "yes", radSaturation = "na", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "low", sensor = "TM", legacy = "collection1"), 674)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "low", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "low", sensor = "TM", legacy = "collection1"), 676)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "med", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "low", sensor = "TM", legacy = "collection1"), 680)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "high", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "low", sensor = "TM", legacy = "collection1"), 684)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "med", cloudShadow = "low",
+                        snow = "low", sensor = "TM", legacy = "collection1"), 704)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "high", sensor = "TM", legacy = "collection1"), 1696)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "low", cloudMask = "no", cloud = "low", cloudShadow = "low",
+                        snow = "high", sensor = "TM", legacy = "collection1"), 1700)
+})
+
+
+test_that("encodeQA MSS collection1 pixel value matching", {
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "na", 
+                        sensor = "MSS", legacy = "collection1"), 0)
+  expect_equal(encodeQA(fill = "yes", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "na", 
+                        sensor = "MSS", legacy = "collection1"), 1)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "yes", radSaturation = "na", cloudMask = "no", cloud = "na", 
+                        sensor = "MSS", legacy = "collection1"), 2)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "low", 
+                        sensor = "MSS", legacy = "collection1"), 32)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "yes", radSaturation = "na", cloudMask = "no", cloud = "low", 
+                        sensor = "MSS", legacy = "collection1"), 34)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "low", cloudMask = "no", cloud = "low", 
+                        sensor = "MSS", legacy = "collection1"), 36)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "med", cloudMask = "no", cloud = "low", 
+                        sensor = "MSS", legacy = "collection1"), 40)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "high", cloudMask = "no", cloud = "low", 
+                        sensor = "MSS", legacy = "collection1"), 44)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "no", cloud = "med", 
+                        sensor = "MSS", legacy = "collection1"), 64)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "low", cloudMask = "no", cloud = "med", 
+                        sensor = "MSS", legacy = "collection1"), 68)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "med", cloudMask = "no", cloud = "med", 
+                        sensor = "MSS", legacy = "collection1"), 72)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "high", cloudMask = "no", cloud = "med", 
+                        sensor = "MSS", legacy = "collection1"), 76)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "na", cloudMask = "yes", cloud = "high", 
+                        sensor = "MSS", legacy = "collection1"), 112)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "low", cloudMask = "yes", cloud = "high", 
+                        sensor = "MSS", legacy = "collection1"), 116)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "med", cloudMask = "yes", cloud = "high", 
+                        sensor = "MSS", legacy = "collection1"), 120)
+  expect_equal(encodeQA(fill = "no", terrainOcclusion = "no", radSaturation = "high", cloudMask = "yes", cloud = "high", 
+                        sensor = "MSS", legacy = "collection1"), 124)
+  
+})
+
+
+test_that("encodeQA OLI pre_collection pixel value matching", {
+  expect_equal(encodeQA(fill = "no", droppedFrame = "no", terrainOcclusion = "no", water = "na", snow = "na", cirrus = "na", cloud = "na",
+                        sensor = "OLI", legacy = "pre_collection"), 0)
+  expect_equal(encodeQA(fill = "yes", droppedFrame = "no", terrainOcclusion = "no", water = "na", snow = "na", cirrus = "na", cloud = "na",
+                        sensor = "OLI", legacy = "pre_collection"), 1)
+  expect_equal(encodeQA(fill = "no", droppedFrame = "yes", terrainOcclusion = "no", water = "na", snow = "na", cirrus = "na", cloud = "na",
+                        sensor = "OLI", legacy = "pre_collection"), 2)
+  expect_equal(encodeQA(fill = "no", droppedFrame = "no", terrainOcclusion = "no", water = "na", snow = "na", cirrus = "high", cloud = "high",
+                        sensor = "OLI", legacy = "pre_collection"), 61440)
+  expect_equal(encodeQA(fill = "no", droppedFrame = "no", terrainOcclusion = "no", water = "na", snow = "high", cirrus = "high", cloud = "high",
+                        sensor = "OLI", legacy = "pre_collection"), 64512)
+})


### PR DESCRIPTION
referring to #28. 
- adds argument `legacy` to choose between `collection1` and `pre_collection` bit designations to encodeQA
- adds argument `sensor` to select Landsat MSS, TM, ETM+, OLI, TIRS for `collection1` and OLI, TIRS for `pre_collection` to encodeQA
- adds Landsat Collection 1 QA single bit parameters `radSaturation`, `cloudMask` (in addition to `cloud`), `droppedPixel`, `cloudShadow` to encodeQA
- adds encodeQA unit tests testing for specific pixel values
- adapted classifyQA, still extracts same classes. Class `cloudShadow` could be added.