### PR TITLE
Provide lower bound for `terra`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Depends:
 Imports:
     caret (>= 6.0-79),
     sf,
-    terra,
+    terra (>= 1.6-41),
     XML,
     dplyr,
     ggplot2,


### PR DESCRIPTION
The function `terra::readRDS` was introduced in v1.6-41 ([bisection](https://github.com/cran/terra/compare/1.6-17...1.6-41#diff-b6b6854a02ae177f8860f49654ff250c1554d021ae434b6efdbe99d00bdc6055)). This PR adds this as a lower bound.